### PR TITLE
Align path with document

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ struct Podcast {
     active_since: Option<i32>,
 }
 
-#[get("/")]
+#[get("/podcast")]
 async fn get_podcast(info: Query<PodcastQuery>) -> Json<Podcast> {
     let podcast = Podcast {
         id: info.into_inner().id,


### PR DESCRIPTION
Fixes the handler was on the root instead of `GET /podcast?id={id}` stated in the [document](https://github.com/discord-podcasts/documentation/blob/main/resources/podcast.md#get-podcastidid).